### PR TITLE
🛠️FIX: Restrict "Name" field to alphabetical letters only

### DIFF
--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -49,6 +49,8 @@ export default function SignupPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 required
+		pattern="[a-zA-Z ]+" oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')" 
+                oninput="this.setCustomValidity('')"
               />
             </div>
             <div className='input-group'>


### PR DESCRIPTION
## Description:
This PR updates the validation for the "Name" field on the Sign-up page to only accept alphabetical letters (a-z, A-Z). This change prevents users from inputting symbols and special characters, reducing the likelihood of invalid or spam submissions.

## Fixes : #375 

## Screenshot

## Before
![image](https://github.com/user-attachments/assets/6e47272a-7195-4784-b49a-a477a5502929)

## After
![image](https://github.com/user-attachments/assets/50e9e1cd-3324-488e-8519-ffac945fdf7f)
